### PR TITLE
Document agent usage guidance

### DIFF
--- a/INBOX.c
+++ b/INBOX.c
@@ -19,6 +19,20 @@ This pattern helps maintain the navigational structure while allowing rapid iter
 
 
 
+/* #codex_experience_report_agents_docs_20251227_1
+
+Goal: document how to run agents from the README and surface the visualization/blog reference for the cmpr workflow.
+
+What changed:
+- Built dist/cmpr to use cmpr navigation commands.
+- Added a README section describing `--agents` listing and `--agent-run` CHECK/FIX usage with root_agent as an example.
+- Linked the README to the #blog_post_blockset_visualization block so readers can find the planned block-graph visualizations.
+- Created .cmpr/revs so cmpr block edits can write revisions locally.
+
+Next steps:
+- Consider adding a helper script that materializes agents/ binaries from the agent blocks to make running them even faster.
+- Flesh out the visualization ideas into an actual blog post or published diagrams linked from the README.
+*/
 /* #claude_experience_report_block_quality_agents_20251227
 
 Experience Report: Creating Block Quality Agents with Correct T Workflow

--- a/INBOX.c
+++ b/INBOX.c
@@ -19,6 +19,24 @@ This pattern helps maintain the navigational structure while allowing rapid iter
 
 
 
+/* #codex_experience_report_agent_docs_refresh_followup_20251228_1
+
+Goal: address feedback on the agent quick-start and keep the repo aligned.
+
+What changed:
+- Rebuilt cmpr and added the missing .cmpr/revs directory so block edits can record revisions.
+- Updated the README "Running agents" steps to clarify how to call ./dist/cmpr, inspect agent wants/impls, and what --agent-run executes.
+
+What works:
+- dist/cmpr builds successfully after make.
+
+Known issues:
+- git pull --rebase could not run because no remote tracking branch is configured.
+
+Next steps:
+- Set an upstream remote if pull/rebase is needed.
+- Revisit the agent docs if further inline review comments surface.
+*/
 /* #codex_experience_report_agents_docs_20251227_1
 
 Goal: document how to run agents from the README and surface the visualization/blog reference for the cmpr workflow.

--- a/INBOX.c
+++ b/INBOX.c
@@ -33,6 +33,19 @@ Next steps:
 - Consider adding a helper script that materializes agents/ binaries from the agent blocks to make running them even faster.
 - Flesh out the visualization ideas into an actual blog post or published diagrams linked from the README.
 */
+/* #codex_experience_report_agent_doc_refresh_20251228_1
+
+Goal: tighten the README agent instructions and clarify the visualization pointer after review feedback.
+
+What changed:
+- Expanded the agent quick-start to cover building `dist/cmpr`, listing agents, inspecting their comments, and running CHECK/FIX with `root_agent` as the example.
+- Reiterated that `--agent-run` materializes scripts from the `_check_impl` and `_fix_impl` blocks so updating the repo keeps agents current.
+- Clarified that the visualization reference in `#blog_post_blockset_visualization` includes hub-and-spoke and force-directed views.
+
+Next steps:
+- Add a short sample of `--agents` output in the README so users know what to expect.
+- Publish or link to the first rendered visualization once the diagrams move beyond the proposal stage.
+*/
 /* #claude_experience_report_block_quality_agents_20251227
 
 Experience Report: Creating Block Quality Agents with Correct T Workflow

--- a/INBOX.c
+++ b/INBOX.c
@@ -19,6 +19,23 @@ This pattern helps maintain the navigational structure while allowing rapid iter
 
 
 
+/* #codex_experience_report_merge_conflict_blocker_20251228_1
+
+Goal: respond to feedback about merge conflicts by verifying the branch state and what is blocking a rebase.
+
+What happened:
+- Rebuilt dist/cmpr to follow cmpr navigation requirements.
+- Checked git status/log to confirm the branch is clean and identify the latest commit.
+- Attempted `git pull --rebase`, which failed because no upstream remote is configured for work.
+
+Current state:
+- Branch work has no tracking remote, so we cannot pull or rebase to resolve upstream conflicts.
+- No local merge conflicts are present; resolution depends on fetching the upstream baseline.
+
+Next steps:
+- Add the correct remote (e.g., `git remote add origin <URL>`), set upstream tracking, and run `git pull --rebase origin <branch>`.
+- After pulling, replay our doc changes with cmpr block edits to avoid large conflicts.
+*/
 /* #codex_experience_report_agent_docs_refresh_followup_20251228_1
 
 Goal: address feedback on the agent quick-start and keep the repo aligned.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ With the clipboard "model," you will want to run ":bootstrap", and then paste th
 If you're using the API, this will be done for you, but you still need to run ":bootstrap" manually before using "r".
 If you use the clipboard model with the palette, it will similarly just put the prompt on the clipboard for you.
 
+## Running agents
+
+cmpr ships agent implementations as blocks, so you can run them directly from the built binary without extra installation steps.
+
+- List available agents with `dist/cmpr --agents` (or `cmpr --agents` if installed system-wide). For example, the current repo includes `root_agent` and `migration_agent`.
+- Run an agent in CHECK or FIX mode with `dist/cmpr --agent-run <agent_name> CHECK` or `dist/cmpr --agent-run <agent_name> FIX`. A common check is `dist/cmpr --agent-run root_agent CHECK` to verify the hub coverage want from `#root`.
+- The `--agent-run` command extracts the shell script from the corresponding `<agent_name>_check_impl` or `<agent_name>_fix_impl` block, writes it to a temp file, and executes it, so keeping your repo up to date is enough to keep agents current.
 ### Bonus: cmpr in cmpr
 
 1. We ship our own cmpr conf file, so run cmpr in the cmpr repo to see the code the way we do while building it.
@@ -180,6 +187,7 @@ This is mostly about how files get broken into blocks.
 Languages that support C-style block comments (Java, JavaScript, Rust, C++, ...) should work without much trouble.
 It's not hard to extend the support to other languages, just ask for what you want in the discord and it may happen soon!
 
+For a visual overview of the cmpr1 block graph and navigation goals, see the `#blog_post_blockset_visualization` block (run `dist/cmpr --print-comment '#blog_post_blockset_visualization'`) for proposed diagrams and a blog-style walkthrough of the workflow.
 ## More
 
 Development is sometimes [streamed on twitch](https://www.twitch.tv/inimino2).

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ If you use the clipboard model with the palette, it will similarly just put the 
 
 cmpr ships agent implementations as blocks, so you can run them directly from the built binary without extra installation steps.
 
-- List available agents with `dist/cmpr --agents` (or `cmpr --agents` if installed system-wide). For example, the current repo includes `root_agent` and `migration_agent`.
-- Run an agent in CHECK or FIX mode with `dist/cmpr --agent-run <agent_name> CHECK` or `dist/cmpr --agent-run <agent_name> FIX`. A common check is `dist/cmpr --agent-run root_agent CHECK` to verify the hub coverage want from `#root`.
-- The `--agent-run` command extracts the shell script from the corresponding `<agent_name>_check_impl` or `<agent_name>_fix_impl` block, writes it to a temp file, and executes it, so keeping your repo up to date is enough to keep agents current.
+1. Build cmpr (`make`) so you have `dist/cmpr` on your PATH (or install system-wide with `sudo make install`).
+2. Discover what's available: `dist/cmpr --agents` lists agent names like `root_agent` and `migration_agent`.
+3. See what an agent does before running it: `dist/cmpr --print-comment '#root_agent'` shows the want it enforces, and `dist/cmpr --print-comment '#root_agent_check_impl'` shows the CHECK implementation it will run.
+4. Run an agent in CHECK or FIX mode with `dist/cmpr --agent-run <agent_name> CHECK` or `dist/cmpr --agent-run <agent_name> FIX`. Example: `dist/cmpr --agent-run root_agent CHECK` verifies the hub coverage want from `#root` and reports gaps; `FIX` attempts the corresponding repair when available.
+5. The `--agent-run` command extracts the shell script from the `<agent_name>_check_impl` or `<agent_name>_fix_impl` block, writes it to a temp file, and executes it, so updating your repo keeps agents current.
 ### Bonus: cmpr in cmpr
 
 1. We ship our own cmpr conf file, so run cmpr in the cmpr repo to see the code the way we do while building it.
@@ -187,7 +189,7 @@ This is mostly about how files get broken into blocks.
 Languages that support C-style block comments (Java, JavaScript, Rust, C++, ...) should work without much trouble.
 It's not hard to extend the support to other languages, just ask for what you want in the discord and it may happen soon!
 
-For a visual overview of the cmpr1 block graph and navigation goals, see the `#blog_post_blockset_visualization` block (run `dist/cmpr --print-comment '#blog_post_blockset_visualization'`) for proposed diagrams and a blog-style walkthrough of the workflow.
+For a visual overview of the cmpr1 block graph and navigation goals, see the `#blog_post_blockset_visualization` block (run `dist/cmpr --print-comment '#blog_post_blockset_visualization'`) for proposed diagrams and a blog-style walkthrough of the workflow, including hub-and-spoke and force-directed views.
 ## More
 
 Development is sometimes [streamed on twitch](https://www.twitch.tv/inimino2).

--- a/README.md
+++ b/README.md
@@ -158,13 +158,17 @@ If you use the clipboard model with the palette, it will similarly just put the 
 
 ## Running agents
 
-cmpr ships agent implementations as blocks, so you can run them directly from the built binary without extra installation steps.
+cmpr ships agent implementations as blocks, so you can run them directly from the built binary.
 
-1. Build cmpr (`make`) so you have `dist/cmpr` on your PATH (or install system-wide with `sudo make install`).
-2. Discover what's available: `dist/cmpr --agents` lists agent names like `root_agent` and `migration_agent`.
-3. See what an agent does before running it: `dist/cmpr --print-comment '#root_agent'` shows the want it enforces, and `dist/cmpr --print-comment '#root_agent_check_impl'` shows the CHECK implementation it will run.
-4. Run an agent in CHECK or FIX mode with `dist/cmpr --agent-run <agent_name> CHECK` or `dist/cmpr --agent-run <agent_name> FIX`. Example: `dist/cmpr --agent-run root_agent CHECK` verifies the hub coverage want from `#root` and reports gaps; `FIX` attempts the corresponding repair when available.
-5. The `--agent-run` command extracts the shell script from the `<agent_name>_check_impl` or `<agent_name>_fix_impl` block, writes it to a temp file, and executes it, so updating your repo keeps agents current.
+1. Build cmpr (`make`) to produce `dist/cmpr`. Use `./dist/cmpr` in the repo root, or `sudo make install` to add `cmpr` to your PATH.
+2. Discover agents: `./dist/cmpr --agents` lists names such as `root_agent` and `migration_agent`.
+3. Inspect what an agent does before executing it:
+   - `./dist/cmpr --print-comment '#root_agent'` shows the want it enforces.
+   - `./dist/cmpr --print-comment '#root_agent_check_impl'` shows the CHECK script it will run (and similarly `_fix_impl`).
+4. Run the agent in CHECK or FIX mode: `./dist/cmpr --agent-run <agent_name> CHECK` or `./dist/cmpr --agent-run <agent_name> FIX`.
+   - Example: `./dist/cmpr --agent-run root_agent CHECK` verifies the hub coverage want from `#root`.
+   - If a FIX implementation exists, `./dist/cmpr --agent-run root_agent FIX` attempts the repair.
+5. `--agent-run` extracts the shell script from the `<agent_name>_check_impl` or `<agent_name>_fix_impl` block, writes it to a temp file, makes it executable, and runs it, so updating your repo keeps agents current.
 ### Bonus: cmpr in cmpr
 
 1. We ship our own cmpr conf file, so run cmpr in the cmpr repo to see the code the way we do while building it.

--- a/doc/agent_notes.md
+++ b/doc/agent_notes.md
@@ -1,0 +1,19 @@
+# Agent workflow notes (conflict-safe)
+
+## Context
+These notes relocate the earlier README/INBOX guidance into a dedicated file to avoid merge conflicts while keeping the instructions available.
+
+## Build and list agents
+- Build the binary: `make`
+- List available agents: `dist/cmpr --agents`
+
+## Inspect and run agents
+- Inspect an agent definition: `dist/cmpr --agent <name>`
+- Dry-run an agent in CHECK mode against a workspace: `dist/cmpr --agent-run <name> CHECK <path>`
+- Apply automated edits in FIX mode: `dist/cmpr --agent-run <name> FIX <path>`
+
+## Visualization reference
+For a visual explanation of the cmpr workflow, see the proposed block-graph diagram and blog-style walkthrough referenced in the documentation plan. The goal is to illustrate how blocks connect and how agents traverse them.
+
+## Merge-conflict note
+Previous attempts to update README.md and INBOX.c conflicted with upstream changes. Future edits should land in standalone files like this one until the branch can rebase cleanly.


### PR DESCRIPTION
## Summary
- Add README instructions for listing available agents and running them in CHECK or FIX modes.
- Link the README to the block-graph visualization blog post concept for a visual overview of the workflow.
- Record the session details in a new INBOX experience report.

## Testing
- make
- dist/cmpr --agents


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc76c43a0832daf1d97005510fbc2)